### PR TITLE
added environment variables hooks for gazebo model path

### DIFF
--- a/botanbot_gazebo/CMakeLists.txt
+++ b/botanbot_gazebo/CMakeLists.txt
@@ -115,6 +115,9 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+# setup environment variables for gazebo model path
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/gazebo_model_path.dsv.in")
+
 ################################################################################
 # Macro for ament package
 ################################################################################

--- a/botanbot_gazebo/hooks/gazebo_model_path.dsv.in
+++ b/botanbot_gazebo/hooks/gazebo_model_path.dsv.in
@@ -1,0 +1,3 @@
+# Setup environment variables for gazebo model path
+prepend-non-duplicate;GAZEBO_MODEL_PATH;share/@PROJECT_NAME@/models
+prepend-non-duplicate;GAZEBO_MODEL_PATH;share/@PROJECT_NAME@/worlds

--- a/botanbot_gui/scripts/start_selected_gazebo_navigation2.sh
+++ b/botanbot_gui/scripts/start_selected_gazebo_navigation2.sh
@@ -6,8 +6,6 @@ source $current_dir/../../../install/setup.bash
 source ~/.bashrc
 echo "going to shut down any active gzserver before starting ..."
 killall gzserver
-# export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
-# export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
 export GAZEBO_WORLD=$GAZEBO_WORLD$1
 ros2_launch_command="ros2 launch botanbot_navigation2 botanbot_simulation.launch.py; bash"
 gnome-terminal -- sh -c "$ros2_launch_command"

--- a/botanbot_gui/scripts/start_selected_gazebo_navigation2.sh
+++ b/botanbot_gui/scripts/start_selected_gazebo_navigation2.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 current_dir="$(dirname "${BASH_SOURCE[0]}")"  # get the directory name
 current_dir="$(realpath "${current_dir}")"    # resolve its full path if
-source /opt/ros/foxy/setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
 source $current_dir/../../../install/setup.bash
 source ~/.bashrc
 echo "going to shut down any active gzserver before starting ..."
 killall gzserver
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
-export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
+# export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
+# export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
 export GAZEBO_WORLD=$GAZEBO_WORLD$1
 ros2_launch_command="ros2 launch botanbot_navigation2 botanbot_simulation.launch.py; bash"
 gnome-terminal -- sh -c "$ros2_launch_command"

--- a/botanbot_gui/scripts/start_selected_gazebo_standalone.sh
+++ b/botanbot_gui/scripts/start_selected_gazebo_standalone.sh
@@ -5,8 +5,6 @@ source /opt/ros/$ROS_DISTRO/setup.bash
 source $current_dir/../../../install/setup.bash
 source ~/.bashrc
 killall gzserver
-# export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
-# export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
 export GAZEBO_WORLD=$GAZEBO_WORLD$1
 ros2_launch_command="ros2 launch botanbot_gazebo botanbot_start_selected_gazebo_world.launch.py; bash"
 gnome-terminal -- sh -c "$ros2_launch_command"

--- a/botanbot_gui/scripts/start_selected_gazebo_standalone.sh
+++ b/botanbot_gui/scripts/start_selected_gazebo_standalone.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 current_dir="$(dirname "${BASH_SOURCE[0]}")"  # get the directory name
 current_dir="$(realpath "${current_dir}")"    # resolve its full path if
-source /opt/ros/foxy/setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
 source $current_dir/../../../install/setup.bash
 source ~/.bashrc
 killall gzserver
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
-export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
+# export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
+# export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
 export GAZEBO_WORLD=$GAZEBO_WORLD$1
 ros2_launch_command="ros2 launch botanbot_gazebo botanbot_start_selected_gazebo_world.launch.py; bash"
 gnome-terminal -- sh -c "$ros2_launch_command"

--- a/botanbot_gui/scripts/start_selected_gazebo_vox_nav.sh
+++ b/botanbot_gui/scripts/start_selected_gazebo_vox_nav.sh
@@ -6,8 +6,6 @@ source $current_dir/../../../install/setup.bash
 source ~/.bashrc
 echo "going to shut down any active gzserver before starting ..."
 killall gzserver
-# export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
-# export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
 export GAZEBO_WORLD=$GAZEBO_WORLD$1
 ros2_launch_command="ros2 launch botanbot_bringup botanbot_simulation.launch.py; bash"
 gnome-terminal -- sh -c "$ros2_launch_command"

--- a/botanbot_gui/scripts/start_selected_gazebo_vox_nav.sh
+++ b/botanbot_gui/scripts/start_selected_gazebo_vox_nav.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 current_dir="$(dirname "${BASH_SOURCE[0]}")"  # get the directory name
 current_dir="$(realpath "${current_dir}")"    # resolve its full path if
-source /opt/ros/foxy/setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
 source $current_dir/../../../install/setup.bash
 source ~/.bashrc
 echo "going to shut down any active gzserver before starting ..."
 killall gzserver
-export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
-export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
+# export GAZEBO_MODEL_PATH=$GAZEBO_MODEL_PATH$current_dir/../../../src/botanbot_sim/botanbot_gazebo/models
+# export GAZEBO_MODEL_PATH=$current_dir/../../../src/botanbot_sim/ros2_full_sensor_suite/models:$GAZEBO_MODEL_PATH
 export GAZEBO_WORLD=$GAZEBO_WORLD$1
 ros2_launch_command="ros2 launch botanbot_bringup botanbot_simulation.launch.py; bash"
 gnome-terminal -- sh -c "$ros2_launch_command"

--- a/ros2_full_sensor_suite/CMakeLists.txt
+++ b/ros2_full_sensor_suite/CMakeLists.txt
@@ -109,6 +109,9 @@ install(DIRECTORY include/
   DESTINATION include/
 )
 
+# setup the environment variable hooks for the gazebo model path
+ament_environment_hooks("${CMAKE_CURRENT_SOURCE_DIR}/hooks/gazebo_model_path.dsv.in")
+
 ################################################################################
 # Macro for ament package
 ################################################################################

--- a/ros2_full_sensor_suite/hooks/gazebo_model_path.dsv.in
+++ b/ros2_full_sensor_suite/hooks/gazebo_model_path.dsv.in
@@ -1,0 +1,2 @@
+# setup the environment variable hooks for the gazebo model path
+prepend-non-duplicate;GAZEBO_MODEL_PATH;share/@PROJECT_NAME@/models


### PR DESCRIPTION
After installing the package I couldnt run the demo gui and launch the worlds and the botanbot properly. I suppose the start shell scripts didnt correctly setup the GAZEBO_MODEL_PATH. Thats why I made the following generic changes. When sourcing the overlay of the botanbot_sim packages `source install/setup.bash`, you can get the following output

`
andi@cni2:~$ echo $GAZEBO_MODEL_PATH 
/home/andi/code/cpp/vox_nav/install/botanbot_gazebo/share/botanbot_gazebo/worlds:/home/andi/code/cpp/vox_nav/install/botanbot_gazebo/share/botanbot_gazebo/models:/home/andi/code/cpp/vox_nav/install/ros2_full_sensor_suite/share/ros2_full_sensor_suite/models
`

- added environment variables hooks for gazebo model path when installing the packages (botanbot_gui, ros2_full_sensor_suite)
- removed the export GAZEBO_MODEL_PATH lines from the start shell scripts
- source $ROS_DISTRO instead of hard coded foxy